### PR TITLE
Updating required version of sass-lint.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint"
   ],
   "dependencies": {
-    "sass-lint": "~1.0.0"
+    "sass-lint": "~1.2.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,12 @@
 
 ## Install
 
-```
+```bash
 npm install grunt-sass-lint --save-dev
+```
+
+If that doesn't work, try:
+
+```bash
+npm install git://github.com/sasstools/grunt-sass-lint.git --save-dev
 ```


### PR DESCRIPTION
I tried installing grunt-sass-lint with the current `master` branch and couldn't get it to work with the example on [the sass-lint README](https://github.com/sasstools/sass-lint/blob/develop/README.md). Updating to `~1.2.0` did the trick.

I also updated the README with the command I had to use to get `npm install` to work for me.