### PR TITLE
Update Sass-lint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint"
   ],
   "dependencies": {
-    "sass-lint": "^1.2.0"
+    "sass-lint": "^1.3.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Bump Sass-lint version from 1.2 to 1.3.

[Changelog](https://github.com/sasstools/sass-lint/blob/develop/CHANGELOG.md)