### PR TITLE
Added an option to quiet warnings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ grunt.initConfig({
 		options: {
 			configFile: 'config/.sass-lint.yml',
 			formatter: 'junit',
+			quiet: 'true',
 			outputFile: 'report.xml'
 		},
 		target: ['location/*.scss']
@@ -63,3 +64,10 @@ Type: `string`
 Default: ``
 
 Will save the generated output to disk instead of command line.
+
+### quiet
+
+Type: `boolean`
+Default: `false`
+
+Silences any warnings that are generated. If this option is true, any amount of warnings will not fail the task. Errors will still fail the task, regardless of this option

--- a/tasks/sass-lint.js
+++ b/tasks/sass-lint.js
@@ -7,7 +7,8 @@ module.exports = function (grunt) {
 
 	grunt.registerMultiTask('sasslint', 'Lint your Sass', function () {
 		var opts = this.options({
-				configFile: ''
+				configFile: '',
+				quiet: false // Makes the task not fail on warnings
 			});
 		var results = [];
 
@@ -15,16 +16,19 @@ module.exports = function (grunt) {
 			results = results.concat(lint.lintFiles(file, opts, opts.configFile));
 		});
 
-		var failResultCount = lint.resultCount(results);
+		var warningCount = lint.warningCount(results).count,
+			errorCount = lint.errorCount(results).count;
 		var resultFormat = lint.format(results, { options: opts });
-
-		if (failResultCount > 0) {
+		if (warningCount + errorCount > 0) {
 			if(opts['outputFile']) {
 				opts['output-file'] = opts['outputFile'];
 				lint.outputResults(results, { options: opts });
-				grunt.fail.warn('');
 			} else {
 				grunt.log.writeln(resultFormat);
+			}
+			// Only fail the task if there are errors or the quiet parameter is off
+			if ((warningCount > 0 && !opts.quiet) ||
+				errorCount > 0) {
 				grunt.fail.warn('');
 			}
 		}


### PR DESCRIPTION
.Allows build systems to continue should there be warnings in the linter. This brings it into line with csslint and the scss-linter, which both have this option