### PR TITLE
Prevents the task filing when the file pattern matches a directory

### DIFF
--- a/tasks/sass-lint.js
+++ b/tasks/sass-lint.js
@@ -12,7 +12,9 @@ module.exports = function (grunt) {
 		var results = [];
 
 		this.filesSrc.forEach(function (file) {
-			results = results.concat(lint.lintFiles(file, opts, opts.configFile));
+			if (grunt.file.isFile(file)) {
+				results = results.concat(lint.lintFiles(file, opts, opts.configFile));
+			}
 		});
 
 		var resultCount = lint.resultCount(results),


### PR DESCRIPTION
Fixes the task running on something like the following

https://github.com/xzyfer/sass-graph/tree/master/test/fixtures

with the pattern: `*.scss`
