### PR TITLE
Add 'force' attribute to options.

### DIFF
--- a/tasks/sass-lint.js
+++ b/tasks/sass-lint.js
@@ -7,6 +7,7 @@ module.exports = function (grunt) {
 
 	grunt.registerMultiTask('sasslint', 'Lint your Sass', function () {
 		var opts = this.options({
+				force: true,
 				configFile: ''
 			});
 		var results = [];
@@ -26,7 +27,10 @@ module.exports = function (grunt) {
 			} else {
 				grunt.log.writeln(resultFormat);
 			}
-      if (errorCount.count > 0) grunt.fail.warn('');
+
+			if(opts.force){
+				if (errorCount.count > 0) grunt.fail.warn('');
+			}
 		}
 	});
 };


### PR DESCRIPTION
Fail grunt build task on error lint.  Why don't we make it be optional?
I have added `force` attribute to options. 
That attribute's default value is true. It will make the task fails when errors occurred.
**That attribute allows the user to choose whether to task fail or not.**